### PR TITLE
Added routing so the user has to tell the bot where s/he enters and leaves the train

### DIFF
--- a/rasa/actions/actions.py
+++ b/rasa/actions/actions.py
@@ -1,11 +1,12 @@
 from typing import Any, Text, Dict, List
 from pyparsing import nestedExpr
-from rasa_sdk import Action, Tracker
+from rasa_sdk import Action, Tracker, FormValidationAction
+from rasa_sdk.events import SlotSet, FollowupAction
 from rasa_sdk.executor import CollectingDispatcher
 import re
 import json
 
-from .api_functions import get_train_data, write_json, prettify_time
+from .api_functions import get_train_data, write_json, load_json, prettify_time, get_station_from_message
 
 
 
@@ -21,8 +22,173 @@ class ActionPrintTrainId(Action):
             dispatcher.utter_message("Dein Zug ist {}.".format(number))
 
         return []
-    
+   
 
+class ActionReadTrainId(Action):
+    def name(self) -> Text:
+        return "action_read_train_id"
+
+    def run(self, dispatcher, tracker, domain):
+        # get latest message sent by user
+        current_state = tracker.current_state()
+        latest_message = current_state["latest_message"]["text"]
+        
+        # find the train id provided by the user using regex, if not found stop function
+        regex_result = re.findall("((ECE|ICE|EC|IC|RE|THA|RJ|FLX|HBX|WB|D|EN|NJ|DN|IRE|MEX|RE|FEX|RB|S)(\s|)(\d{1,5}))", latest_message.upper())
+        special_trains = {
+            "train": ["RE", "RB", "S"],
+        }
+
+        if len(regex_result) > 0:
+            if regex_result[0][1] in special_trains["train"]:
+                dispatcher.utter_message(f"{regex_result[0][0]} ist eine Zuglinie, kein Zug. Zur Zeit habe ich dazu leider keine Informationen.")
+                return []
+            else:
+                train_id = regex_result[0][0]
+        else:
+            dispatcher.utter_message("Tut mit leid, ich habe nicht verstanden welchen Zug du nehmen möchtest!")
+            return []
+
+        # fetch data from bahn.expert given the train id
+        train_data = get_train_data(train_id)
+
+        # if the train is not found, tell user
+        if train_data == -1:
+            dispatcher.utter_message(f"Tut mir leid, ich konnte den Zug {train_id} nicht finden!")
+            return []
+
+        # check if train is already cancelled
+        cancelled = False
+        if "cancelled" in train_data:
+            if train_data["cancelled"]:
+                cancelled = True
+                dispatcher.utter_message(f"Oje! Dein Zug {train_id} fällt aus!")
+                return []
+
+        # create inital train data object and store all stops
+        initial_train_data = {
+            "trainId": train_id,
+            "from": "",
+            "to": "",
+            "departureTime": "",
+            "arrivalTime": "",
+            "platform": "",
+            "actualDepartureTime": "",
+            "actualArrivalTime": "",
+            "departureDelay": "",
+            "arrivalDelay": "",
+            "cancelled": cancelled,
+            "stops": train_data["stops"]
+        }
+
+        # store user and train data
+        write_json("../data/new_user_data.json", tracker.sender_id, initial_train_data)
+
+        return [FollowupAction("stations_form")]
+
+
+
+class ValidateStationsForm(FormValidationAction):
+    def name(self) -> Text:
+        return "validate_stations_form"
+
+    def validate_departure_station(self, slot_value: Any, dispatcher: CollectingDispatcher, tracker: Tracker, domain) -> Dict[Text, Any]:
+        train_data = load_json("../data/new_user_data.json")[tracker.sender_id]
+        departure_station_name = get_station_from_message(train_data["stops"], slot_value)[0][0]
+        stop_data = list(filter(lambda station: station["station"]["title"] == departure_station_name, train_data["stops"]))[0]
+
+        train_data["from"] = departure_station_name
+        train_data["departureTime"] = stop_data["departure"]["scheduledTime"]
+        train_data["actualDepartureTime"] = stop_data["departure"]["time"]
+
+        if "platform" in stop_data["departure"]:
+            train_data["platform"] = stop_data["departure"]["platform"]
+
+        if "delay" in stop_data["departure"]:
+            train_data["departureDelay"] = stop_data["departure"]["delay"]
+
+        write_json("../data/new_user_data.json", tracker.sender_id, train_data)
+
+        return { "departure_station": slot_value }
+
+    def validate_arrival_station(self, slot_value: Any, dispatcher: CollectingDispatcher, tracker: Tracker, domain) -> Dict[Text, Any]:
+        train_data = load_json("../data/new_user_data.json")[tracker.sender_id]
+        arrival_station_name = get_station_from_message(train_data["stops"], slot_value)[0][0]
+        stop_data = list(filter(lambda station: station["station"]["title"] == arrival_station_name, train_data["stops"]))[0]
+
+        train_data["to"] = arrival_station_name
+        train_data["arrivalTime"] = stop_data["arrival"]["scheduledTime"]
+        train_data["actualArrivalTime"] = stop_data["arrival"]["time"]
+
+        if "delay" in stop_data["arrival"]:
+            train_data["arrivalDelay"] = stop_data["arrival"]["delay"]
+
+        # save initial train information
+        write_json("../data/new_user_data.json", tracker.sender_id, train_data)
+
+        response_message = f"Alles klar, ich informiere dich über den Zug **{train_data['trainId']}**! Zugdaten:\n" \
+                        f" **Von:** {train_data['from']}\n" \
+                        f" **Nach:** {train_data['to']}\n" \
+                        f" **Abfahrtszeit:** {prettify_time(train_data['departureTime'])}\n" \
+                        f" **Ankunftszeit:** {prettify_time(train_data['arrivalTime'])}\n" \
+                        f" **Glies:** {train_data['platform']}\n"
+
+        # answer user
+        dispatcher.utter_message(response_message)
+
+        # check if the train got cancelled and notify the user
+        if train_data["cancelled"]:
+            dispatcher.utter_message(f"Oje! Dein Zug {train_data['trainId']} fällt aus!")
+            return []
+
+        about_changes_message = ""
+
+        # check if there is a delay and nofity the user
+        departure_delay = ""
+        if train_data["departureDelay"]:
+            departure_delay = train_data["departureDelay"]
+            if departure_delay > 0:
+                about_changes_message += f"**Abfahrtsverzögerung:** {departure_delay} Minuten! Neue Abfahrtszeit: {prettify_time(train_data['actualDepartureTime'])}.\n"
+        
+        arrival_delay = ""
+        if train_data["arrivalDelay"]:
+            arrival_delay = train_data["arrivalDelay"]
+            if arrival_delay > 0:
+                about_changes_message += f"**Ankunftsverzögerung:** {arrival_delay} Minuten! Neue Ankunftszeit: {prettify_time(train_data['actualArrivalTime'])}.\n"
+        
+        if len(about_changes_message) > 0:
+                dispatcher.utter_message(about_changes_message)
+
+        return { "arrival_station": slot_value }
+
+
+
+
+class ActionToTrigger(Action):
+     def name(self) -> Text:
+        return "action_train_data_change"
+         
+     def run(self, dispatcher, tracker, domain):
+        train_entity_type = tracker.get_slot("train_entity_type")
+        train_entity_value = tracker.get_slot("train_entity_value")
+
+        if train_entity_type == "departure_delay":
+            departure_delay, new_departure_time = train_entity_value.split(";")
+            dispatcher.utter_message(f"**Achtung!** Dein Zug verspätet sich um {departure_delay} Minuten.\nNeue Abfahrtszeit: {prettify_time(new_departure_time)}.")
+
+        elif train_entity_type == "arrival_delay":
+            arrival_delay, new_arrival_time = train_entity_value.split(";")
+            dispatcher.utter_message(f"**Achtung!** Deine Zugreise verlängert sich um {arrival_delay} Minuten.\nNeue Ankunftszeit: {prettify_time(new_arrival_time)}.")
+
+        elif train_entity_type == "platform_change":
+            dispatcher.utter_message(f"**Achtung!** Dein Gleis hat sich geändert.\nNeues Gleis: {train_entity_value}.")
+
+        elif train_entity_type == "cancellation":
+            dispatcher.utter_message(f"**Achtung!** Dein Zug fällt aus!")
+
+
+ 
+"""
 class ActionStoreTrainData(Action):
      def name(self) -> Text:
         return "action_store_train_data"
@@ -112,27 +278,157 @@ class ActionStoreTrainData(Action):
         write_json("../data/user_data.json", tracker.sender_id, cleaned_train_data)
 
         return []
+"""
 
 
 
-class ActionToTrigger(Action):
-     def name(self) -> Text:
-        return "action_train_data_change"
-         
-     def run(self, dispatcher, tracker, domain):
-        train_entity_type = tracker.get_slot("train_entity_type")
-        train_entity_value = tracker.get_slot("train_entity_value")
+""" TO BE DELETED
+class ActionReadStation(Action):
+    def name(self) -> Text:
+        return "action_read_station"
 
-        if train_entity_type == "departure_delay":
-            departure_delay, new_departure_time = train_entity_value.split(";")
-            dispatcher.utter_message(f"**Achtung!** Dein Zug verspätet sich um {departure_delay} Minuten.\nNeue Abfahrtszeit: {prettify_time(new_departure_time)}.")
+    def run(self, dispatcher, tracker, domain):
+        # get latest message sent by user
+        dispatcher.utter_message("Super!")
+        return []
+        current_state = tracker.current_state()
+        latest_message = current_state["latest_message"]["text"]
+        
+        train_data = load_json("../data/new_user_data.json")[tracker.sender_id]
+        station_name = get_station_from_message(train_data["stops"], latest_message)[0]
+        stop_data = filter(lambda station: station["station"]["title"] == station_name, train_data["stops"])
 
-        elif train_entity_type == "arrival_delay":
-            arrival_delay, new_arrival_time = train_entity_value.split(";")
-            dispatcher.utter_message(f"**Achtung!** Deine Zugreise verlängert sich um {arrival_delay} Minuten.\nNeue Ankunftszeit: {prettify_time(new_arrival_time)}.")
+        if train_data["departureStation"] != "":            
+            train_data["from"] = station_name
+            train_data["departureTime"] = stop_data["departure"]["scheduledTime"]
+            train_data["actualDepartureTime"] = stop_data["departure"]["time"]
 
-        elif train_entity_type == "platform_change":
-            dispatcher.utter_message(f"**Achtung!** Dein Gleis hat sich geändert.\nNeues Gleis: {train_entity_value}.")
+            if "platform" in train_data["departure"]:
+                train_data["platform"] = stop_data["departure"]["platform"]
 
-        elif train_entity_type == "cancellation":
-            dispatcher.utter_message(f"**Achtung!** Dein Zug fällt aus!")            
+            if "delay" in train_data["arrival"]:
+                train_data["departureDelay"] = stop_data["departure"]["delay"]
+
+            write_json("../data/new_user_data.json", tracker.sender_id, train_data)
+
+            dispatcher.utter_message("Und wo steigst du aus?")
+        else:            
+            train_data["to"] = station_name
+            train_data["arrivalTime"] = stop_data["arrival"]["scheduledTime"]
+            train_data["actualArrivalTime"] = stop_data["arrival"]["time"]
+
+            if "delay" in train_data["arrival"]:
+                train_data["arrivalDelay"] = stop_data["arrival"]["delay"]
+
+            write_json("../data/new_user_data.json", tracker.sender_id, train_data)
+
+            response_message = f"Alles klar, ich informiere dich über den Zug **{train_data['trainId']}**! Zugdaten:\n" \
+                            f" **Von:** {train_data['from']}\n" \
+                            f" **Nach:** {train_data['to']}\n" \
+                            f" **Abfahrtszeit:** {prettify_time(train_data['departureTime']['scheduledTime'])}\n" \
+                            f" **Ankunftszeit:** {prettify_time(train_data['arrivalTime']['scheduledTime'])}\n" \
+                            f" **Glies:** {train_data['platform']}\n"
+
+            # answer user
+            dispatcher.utter_message(response_message)
+
+            # check if the train got cancelled and notify the user
+            if train_data["cancelled"]:
+                dispatcher.utter_message(f"Oje! Dein Zug {train_data['trainId']} fällt aus!")
+                return []
+
+            about_changes_message = ""
+
+            # check if there is a delay and nofity the user
+            departure_delay, arrival_delay = "", ""
+            if train_data["departureDelay"]:
+                departure_delay = train_data["departureDelay"]
+                if departure_delay > 0:
+                    about_changes_message += f"**Abfahrtsverzögerung:** {departure_delay} Minuten! Neue Abfahrtszeit: {prettify_time(train_data['departure']['time'])}.\n"
+                
+            if train_data["arrivalDelay"]:
+                arrival_delay = train_data["departureDelay"]
+                if arrival_delay > 0:
+                    about_changes_message += f"**Ankunftsverzögerung:** {arrival_delay} Minuten! Neue Ankunftszeit: {prettify_time(train_data['arrival']['time'])}.\n"
+            
+            if len(about_changes_message) > 0:
+                dispatcher.utter_message(about_changes_message)
+
+
+class ActionReadStations(Action):
+    def name(self) -> Text:
+        return "action_read_stations"
+
+    def run(self, dispatcher, tracker, domain):
+        # get latest message sent by user
+        # current_state = tracker.current_state()
+        # latest_message = current_state["latest_message"]["text"]
+        dispatcher.utter_message("Got it!")
+
+        train_data = load_json("../data/new_user_data.json")[tracker.sender_id]
+
+        # set departure information
+        given_departure_station_name = tracker.get_slot("departure_station")
+        departure_station_name = get_station_from_message(train_data["stops"], given_departure_station_name)[0]
+
+        stop_data = filter(lambda station: station["station"]["title"] == departure_station_name, train_data["stops"])
+
+        train_data["from"] = departure_station_name
+        train_data["departureTime"] = stop_data["departure"]["scheduledTime"]
+        train_data["actualDepartureTime"] = stop_data["departure"]["time"]
+
+        if "platform" in train_data["departure"]:
+            train_data["platform"] = stop_data["departure"]["platform"]
+
+        if "delay" in train_data["arrival"]:
+            train_data["departureDelay"] = stop_data["departure"]["delay"]
+
+        # set arrival information
+        given_arrival_station_name = tracker.get_slot("arrival_station")
+        arrival_station_name = get_station_from_message(train_data["stops"], given_arrival_station_name)[0]
+
+        stop_data = filter(lambda station: station["station"]["title"] == arrival_station_name, train_data["stops"])
+
+        train_data["to"] = arrival_station_name
+        train_data["arrivalTime"] = stop_data["arrival"]["scheduledTime"]
+        train_data["actualArrivalTime"] = stop_data["arrival"]["time"]
+
+        if "delay" in train_data["arrival"]:
+            train_data["arrivalDelay"] = stop_data["arrival"]["delay"]
+
+        # save initial train information
+        write_json("../data/new_user_data.json", tracker.sender_id, train_data)
+
+        response_message = f"Alles klar, ich informiere dich über den Zug **{train_data['trainId']}**! Zugdaten:\n" \
+                        f" **Von:** {train_data['from']}\n" \
+                        f" **Nach:** {train_data['to']}\n" \
+                        f" **Abfahrtszeit:** {prettify_time(train_data['departureTime']['scheduledTime'])}\n" \
+                        f" **Ankunftszeit:** {prettify_time(train_data['arrivalTime']['scheduledTime'])}\n" \
+                        f" **Glies:** {train_data['platform']}\n"
+
+        # answer user
+        dispatcher.utter_message(response_message)
+
+        # check if the train got cancelled and notify the user
+        if train_data["cancelled"]:
+            dispatcher.utter_message(f"Oje! Dein Zug {train_data['trainId']} fällt aus!")
+            return []
+
+        about_changes_message = ""
+
+        # check if there is a delay and nofity the user
+        departure_delay, arrival_delay = "", ""
+        if train_data["departureDelay"]:
+            departure_delay = train_data["departureDelay"]
+            if departure_delay > 0:
+                about_changes_message += f"**Abfahrtsverzögerung:** {departure_delay} Minuten! Neue Abfahrtszeit: {prettify_time(train_data['departure']['time'])}.\n"
+            
+        if train_data["arrivalDelay"]:
+            arrival_delay = train_data["departureDelay"]
+            if arrival_delay > 0:
+                about_changes_message += f"**Ankunftsverzögerung:** {arrival_delay} Minuten! Neue Ankunftszeit: {prettify_time(train_data['arrival']['time'])}.\n"
+        
+        if len(about_changes_message) > 0:
+                dispatcher.utter_message(about_changes_message)"""
+
+

--- a/rasa/actions/actions.py
+++ b/rasa/actions/actions.py
@@ -135,7 +135,7 @@ class ValidateStationsForm(FormValidationAction):
         train_data = load_json("../data/user_data.json")[tracker.sender_id]
 
         # get list of the possible station names and confidences the user could have meant (optimal only one station in list)
-        departure_station_name = get_station_from_message(train_data["stops"], slot_value, threshold=0.65)
+        departure_station_name = get_station_from_message(train_data["stops"], slot_value, threshold=0.6)
 
         # if it's -1 it means that the station name the user provided hasn't been found
         if departure_station_name == -1:
@@ -189,8 +189,8 @@ class ValidateStationsForm(FormValidationAction):
         train_data = load_json("../data/user_data.json")[tracker.sender_id]
     
         # get list of the possible station names and confidences the user could have meant (optimal only one station in list)
-        arrival_station_name = get_station_from_message(train_data["stops"], slot_value, threshold=0.65)
-
+        arrival_station_name = get_station_from_message(train_data["stops"], slot_value, threshold=0.6)
+    
         # if it's -1 it means that the station name the user provided hasn't been found
         if arrival_station_name == -1:
 

--- a/rasa/actions/api_functions.py
+++ b/rasa/actions/api_functions.py
@@ -69,12 +69,19 @@ def prettify_time(time: str) -> str:
         return time_day_and_time
     
 
-def get_station_from_message(train_stops: dict, message: str) -> list[str]:
-    station_scores = {}
+def get_station_from_message(train_stops: dict, message: str, threshold: float) -> list[str]:
+    found, station_scores = False, {}
     for stop in train_stops:
         station_name = stop["station"]["title"]
         fuzzy_score = fuzz.partial_ratio(station_name, message)
+
+        if fuzzy_score > threshold * 100:
+            found = True
+
         station_scores[station_name] = fuzzy_score
+
+    if not found:
+        return -1
 
     return [(k, v) for k, v in station_scores.items() if v == max(station_scores.values())]
 

--- a/rasa/actions/api_functions.py
+++ b/rasa/actions/api_functions.py
@@ -78,19 +78,15 @@ def get_station_from_message(train_stops: dict, message: str, threshold: float) 
         pattern = re.compile("Hauptbahnhof", re.IGNORECASE)
         message = pattern.sub("Hbf", message)
         
-        #station_name.replace("Hauptbahnhof", "Hbf")
-        #message.replace("Hauptbahnhof", "Hbf")
-
         # calculate similarity score
         fuzzy_score = fuzz.token_set_ratio(message, station_name)
-        #if message.lower() in station_name.lower():
-        #   fuzzy_score += 25
+
 
         if fuzzy_score > threshold * 100:
             found = True
 
         station_scores[station_name] = fuzzy_score
-    print(station_scores)
+
     if not found:
         return -1
 

--- a/rasa/actions/api_functions.py
+++ b/rasa/actions/api_functions.py
@@ -5,6 +5,7 @@ import os
 from dateutil import parser
 from datetime import date, timedelta
 import locale
+import re
 from fuzzywuzzy import fuzz
 
 
@@ -73,13 +74,23 @@ def get_station_from_message(train_stops: dict, message: str, threshold: float) 
     found, station_scores = False, {}
     for stop in train_stops:
         station_name = stop["station"]["title"]
-        fuzzy_score = fuzz.partial_ratio(station_name, message)
+
+        pattern = re.compile("Hauptbahnhof", re.IGNORECASE)
+        message = pattern.sub("Hbf", message)
+        
+        #station_name.replace("Hauptbahnhof", "Hbf")
+        #message.replace("Hauptbahnhof", "Hbf")
+
+        # calculate similarity score
+        fuzzy_score = fuzz.token_set_ratio(message, station_name)
+        #if message.lower() in station_name.lower():
+        #   fuzzy_score += 25
 
         if fuzzy_score > threshold * 100:
             found = True
 
         station_scores[station_name] = fuzzy_score
-
+    print(station_scores)
     if not found:
         return -1
 

--- a/rasa/config.yml
+++ b/rasa/config.yml
@@ -32,6 +32,22 @@ language: de
 # Configuration for Rasa Core.
 # https://rasa.com/docs/rasa/core/policies/
 #policies:
+policies:
+# # No configuration for policies was provided. The following default policies were used to train your model.
+# # If you'd like to customize them, uncomment and adjust the policies.
+# # See https://rasa.com/docs/rasa/policies for more information.
+  - name: MemoizationPolicy
+  - name: RulePolicy
+  - name: UnexpecTEDIntentPolicy
+    max_history: 5
+    epochs: 100
+  - name: TEDPolicy
+    max_history: 5
+    epochs: 100
+    constrain_similarities: true
+  #- name: RulePolicy
+  #- name: TEDPolicy
+  #  max_history: 5
 # # No configuration for policies was provided. The following default policies were used to train your model.
 # # If you'd like to customize them, uncomment and adjust the policies.
 # # See https://rasa.com/docs/rasa/policies for more information.
@@ -67,7 +83,6 @@ pipeline:
   - name: FallbackClassifier
     threshold: 0.95
 
-policies:
 # # No configuration for policies was provided. The following default policies were used to train your model.
 # # If you'd like to customize them, uncomment and adjust the policies.
 # # See https://rasa.com/docs/rasa/policies for more information.

--- a/rasa/data/nlu.yml
+++ b/rasa/data/nlu.yml
@@ -109,5 +109,19 @@ nlu:
   examples: |
     - ((ECE|ICE|EC|IC|RE|THA|RJ|FLX|HBX|WB|D|EN|NJ|DN|IRE|MEX|RE|FEX|RB|S)(\s|)(\d{1,5}))
 
+- intent: give_departure_station
+  examples: |
+    - [München HBF](departure_station)
+    - [Frankfurt Hauptbahnhof](departure_station)
+    - [Ingolstadt](departure_station)
+    - [Tübingen Hbf](departure_station)
 
+
+#- intent: give_arrival_station
+#  examples: |
+#    - [München HBF](arrival_station)
+#    - [Frankfurt Hauptbahnhof](arrival_station)
+#    - [Ingolstadt Hbf](arrival_station)
+#    - [Tübingen Hbf](arrival_station)
+#    - [Tübingen](arrival_station)
 

--- a/rasa/data/nlu.yml
+++ b/rasa/data/nlu.yml
@@ -105,16 +105,27 @@ nlu:
     - ich finde meinen Gleis am Münchner HBF nicht!
     - wie komme ich zu Gleis 10 am Münchner HBF?
 
+- intent: abort
+  examples: |
+    - stopp
+    - Stop!
+    - abbruch!
+    - nochmal von vorne
+    - das war falsch
+    - neu anfangen
+    - aufhören!
+    
+
 - regex: train_id
   examples: |
     - ((ECE|ICE|EC|IC|RE|THA|RJ|FLX|HBX|WB|D|EN|NJ|DN|IRE|MEX|RE|FEX|RB|S)(\s|)(\d{1,5}))
 
-- intent: give_departure_station
-  examples: |
-    - [München HBF](departure_station)
-    - [Frankfurt Hauptbahnhof](departure_station)
-    - [Ingolstadt](departure_station)
-    - [Tübingen Hbf](departure_station)
+# - intent: give_departure_station
+#   examples: |
+#     - [München HBF](departure_station)
+#     - [Frankfurt Hauptbahnhof](departure_station)
+#     - [Ingolstadt](departure_station)
+#     - [Tübingen Hbf](departure_station)
 
 
 #- intent: give_arrival_station

--- a/rasa/data/rules.yml
+++ b/rasa/data/rules.yml
@@ -11,20 +11,21 @@ rules:
   - intent: check_status
   - action: utter_pong
 
+# no need for this since anymore, gonnda delete soon
+#- rule: Get inital train data if the user provides a train-id.
+#  steps:
+#  - intent: give_train_id
+#  - action: action_store_train_data
+
 - rule: Get inital train data if the user provides a train-id.
   steps:
   - intent: give_train_id
-  - action: action_store_train_data
+  - action: action_read_train_id
 
 - rule: Greet the user. 
   steps:
   - intent: greet
   - action: utter_greet
-
-#- rule: Answer 'how are you?'.
-#  steps:
-#  - intent: ask_mood
-#  - action: utter_mood
 
 - rule: Give help.
   steps:

--- a/rasa/data/rules.yml
+++ b/rasa/data/rules.yml
@@ -52,4 +52,9 @@ rules:
   - intent: get_platform_plan
   - action: utter_platform_plan
 
+- rule: React to abort action.
+  steps:
+  - intent: abort
+  - action: utter_react_to_abort
+
 

--- a/rasa/data/stories.yml
+++ b/rasa/data/stories.yml
@@ -1,10 +1,10 @@
 version: "3.0"
 
 stories:
-- story: get inital train data path
-  steps:
-  - intent: get_train_id
-  - action: action_print_train_id
+#- story: get inital train data path
+#  steps:
+#  - intent: get_train_id
+#  - action: action_print_train_id
 
 - story: ask good mood
   steps:

--- a/rasa/domain.yml
+++ b/rasa/domain.yml
@@ -12,11 +12,17 @@ intents:
   - notify_train_data_change
   - chitchat
   - get_platform_plan
+  - give_departure_station
+  - give_arrival_station
+  - give_arrival_stations
   
 actions:
   - action_print_train_id
   - action_store_train_data
   - action_train_data_change
+  - action_read_train_id
+  - action_read_stations
+  - validate_stations_form
 
 entities:
   - train_id
@@ -24,12 +30,33 @@ entities:
   - train_entity_value
 
 slots:
+  # stores the train id given by the user
   train_id:
     type: text
     influence_conversation: true
     mappings:
     - type: from_entity
       entity: train_id
+
+  # stores the departue station given by the user
+  departure_station:
+    type: text
+    influence_conversation: true
+    mappings:
+    - type: from_text
+      conditions:
+      - active_loop: stations_form
+        requested_slot: departure_station
+  
+  # stores the arrival station given by the user
+  arrival_station:
+    type: text
+    influence_conversation: true
+    mappings:
+    - type: from_text
+      conditions:
+      - active_loop: stations_form
+        requested_slot: arrival_station
 
   # stores the type of train data that changed (e.g. "platform", "departure_delay", ...)
   train_entity_type:
@@ -46,6 +73,14 @@ slots:
     mappings:
     - type: from_entity
       entity: train_entity_value
+
+
+forms:
+  stations_form:
+    required_slots:
+      - departure_station
+      - arrival_station
+      
 
 responses:
   utter_pong:
@@ -105,7 +140,11 @@ responses:
   - text: "Hier ist der Gleisplan vom Münchner HBF:"
     image: https://images.gutefrage.net/media/fragen/bilder/wo-befindet-sich-im-muenchener-hbf-das-gleis-10-fluegelbahnhof/0_big.jpg?v=1478258160000
 
+  utter_ask_departure_station:
+  - text: In welcher Station steigst du ein?
 
+  utter_ask_arrival_station:
+  - text: In welcher Station steigst du aus?
 
 session_config:
   session_expiration_time: 60

--- a/rasa/domain.yml
+++ b/rasa/domain.yml
@@ -15,6 +15,7 @@ intents:
   - give_departure_station
   - give_arrival_station
   - give_arrival_stations
+  - abort
   
 actions:
   - action_print_train_id
@@ -145,6 +146,10 @@ responses:
 
   utter_ask_arrival_station:
   - text: In welcher Station steigst du aus?
+
+  utter_react_to_abort:
+  - text: Oh, okay!
+  - text: Oje, alles klar!
 
 session_config:
   session_expiration_time: 60

--- a/rasa/story_graph.dot
+++ b/rasa/story_graph.dot
@@ -1,0 +1,23 @@
+digraph  {
+0 [class="start active", fillcolor=green, fontsize=12, label=START, style=filled];
+"-1" [class=end, fillcolor=red, fontsize=12, label=END, style=filled];
+1 [class=active, fontsize=12, label=action_session_start];
+2 [class=active, fontsize=12, label=action_read_train_id];
+3 [class=active, fontsize=12, label=stations_form];
+7 [class=active, fontsize=12, label=utter_chitchat];
+8 [class="intent dashed active", label="  ?  ", shape=rect];
+9 [class="intent active", fillcolor=lightblue, label="/give_train_id", shape=rect, style=filled];
+10 [class="intent active", fillcolor=lightblue, label="/nlu_fallback", shape=rect, style=filled];
+11 [class="intent active", fillcolor=lightblue, label="/chitchat", shape=rect, style=filled];
+0 -> "-1"  [class="", key=NONE, label=""];
+0 -> 1  [class=active, key=NONE, label=""];
+1 -> 9  [class=active, key=0];
+2 -> 3  [class=active, key=NONE, label=""];
+3 -> 3  [class=active, key=NONE, label=""];
+3 -> 10  [class=active, key=0];
+3 -> 11  [class=active, key=0];
+7 -> 8  [class=active, key=NONE, label=""];
+9 -> 2  [class=active, key=0];
+10 -> 3  [class=active, key=0];
+11 -> 7  [class=active, key=0];
+}

--- a/train-monitoring/monitoring.py
+++ b/train-monitoring/monitoring.py
@@ -76,8 +76,6 @@ def check_train_changes(user_data_path: str) -> None:
 
             trigger_chatbot_message(conversation_id, "departure_delay", departure_delay)
 
-        print(arrival_station["arrival"]["time"], current_train_data["actualArrivalTime"])
-
 
         # check if the arrival time changed
         if arrival_station["arrival"]["time"] != current_train_data["actualArrivalTime"]:

--- a/train-monitoring/monitoring.py
+++ b/train-monitoring/monitoring.py
@@ -53,17 +53,21 @@ def check_train_changes(user_data_path: str) -> None:
         # get data from train id
         new_train_data = get_train_data(train_id)
 
+        # get data about the departure and arrival station
+        departure_station = list(filter(lambda station: station["station"]["title"] == current_train_data["from"], new_train_data["stops"]))[0]
+        arrival_station = list(filter(lambda station: station["station"]["title"] == current_train_data["to"], new_train_data["stops"]))[0]
+
         # check if the train got cancelled
-        if "cancelled" in new_train_data:
-            current_train_data["cancelled"] = new_train_data["cancelled"]
+        if "cancelled" in departure_station:
+            current_train_data["cancelled"] = departure_station["cancelled"]
 
             trigger_chatbot_message(conversation_id, "cancellation", "")
             continue
 
         # check if the departure time changed
-        if new_train_data["departure"]["time"] != current_train_data["actualDepartureTime"]:    
-            new_departure_time = new_train_data["departure"]["time"]
-            departure_delay = new_train_data["departure"]["delay"]
+        if departure_station["departure"]["time"] != current_train_data["actualDepartureTime"]:    
+            new_departure_time = departure_station["departure"]["time"]
+            departure_delay = departure_station["departure"]["delay"]
             current_train_data["actualDepartureTime"] = new_departure_time
             current_train_data["departureDelay"] = departure_delay
 
@@ -72,10 +76,14 @@ def check_train_changes(user_data_path: str) -> None:
 
             trigger_chatbot_message(conversation_id, "departure_delay", departure_delay)
 
+        print(arrival_station["arrival"]["time"], current_train_data["actualArrivalTime"])
+
+
         # check if the arrival time changed
-        if new_train_data["arrival"]["time"] != current_train_data["actualArrivalTime"]:
-            new_arrival_time = new_train_data["arrival"]["time"]
-            arrival_delay = new_train_data["arrival"]["delay"]
+        if arrival_station["arrival"]["time"] != current_train_data["actualArrivalTime"]:
+            print("jir")
+            new_arrival_time = arrival_station["arrival"]["time"]
+            arrival_delay = arrival_station["arrival"]["delay"]
             current_train_data["actualArrivalTime"] = new_arrival_time
             current_train_data["arrivalDelay"] = arrival_delay
 
@@ -86,8 +94,8 @@ def check_train_changes(user_data_path: str) -> None:
 
 
         # check if the platorm changed
-        if new_train_data["departure"]["platform"] != current_train_data["platform"]:
-            new_platform = new_train_data["departure"]["platform"]
+        if departure_station["departure"]["platform"] != current_train_data["platform"]:
+            new_platform = departure_station["departure"]["platform"]
             current_train_data["platform"] = new_platform
 
             trigger_chatbot_message(conversation_id, "platform_change", new_platform)


### PR DESCRIPTION
Bitte ausprobieren :) 
Dafür müsst ihr jetzt immer wissen welche Stationen der Zug durchfährt und in welcher Reihenfolge.
Wenn ihr dem Bot zB. sagt "ich nehme den ICE621" und der bot euch fragt wo ihr ein- und aussteigt schaut euch mit diesem Endpoint an welcher Stationen der Zug durchfährt:

> https://bahn.expert/api/hafas/v2/details/ICE612

Versucht den Bot gerne "kaputt" zu machen (zB in dem ihr beim einsteigen eine Station eingebt die NACH der Aussteigestation kommt was natürlich keinen Sinn macht; oder indem ihr Stationen eingeben die nicht exisitieren).

## Edit:
Achtung! Ihr müsst das Package "fuzzywuzzy" installieren, ich mach das noch demnächst in die Dokumentation. Zum installieren führt folgendes in der Konsole aus:
```
pip install fuzzywuzzy
```